### PR TITLE
Fix simulation layout and equations

### DIFF
--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -482,7 +482,7 @@
                     plot_bgcolor: 'rgba(0,0,0,0)',
                     font: { color: getComputedStyle(document.body).getPropertyValue('--text-color') },
                     showlegend: true,
-                    legend: { x: 1, y: 1 },
+                    legend: { x: 0.95, y: 0.95, xanchor: 'right', yanchor: 'top', bgcolor: 'rgba(0,0,0,0)' },
                     margin: { t: 40, r: 20, l: 50, b: 40 }
                 };
 


### PR DESCRIPTION
Updates to the licensing simulation page:
- Moved chart legend inside the plot area.
- Compacted equation display and removed scrollbars.
- Renamed 'Parameter p' to 'Matching probability (p)'.
- Fixed Production Function equation display.