### PR TITLE
Move mobile equations to bottom-left and compact desktop controls

### DIFF
--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -30,7 +30,7 @@
         
         .controls-container {
             background: var(--card-bg);
-            padding: 1.5rem;
+            padding: 1rem; /* Reduced from 1.5rem */
             border-radius: 12px;
             border: 1px solid var(--border-color);
             box-shadow: var(--shadow-sm);
@@ -38,14 +38,14 @@
 
         .controls-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* Reduced min-width from 250px */
+            gap: 1rem; /* Reduced from 1.5rem */
         }
 
         .control-group {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
+            gap: 0.25rem; /* Reduced from 0.5rem */
         }
 
         .control-group label {
@@ -53,11 +53,13 @@
             color: var(--text-color);
             display: flex;
             justify-content: space-between;
+            font-size: 0.9rem; /* Slightly smaller font */
         }
 
         .control-group input[type="range"] {
             width: 100%;
             accent-color: var(--accent-color);
+            height: 4px; /* Thinner slider track */
         }
 
         .charts-container {
@@ -227,10 +229,10 @@
                 border: 1px solid var(--border-color);
                 opacity: 0.9;
                 /* Reset positions to be safer */
-                top: 10px !important;
-                right: 10px !important;
-                bottom: auto !important;
-                left: auto !important;
+                top: auto !important;
+                right: auto !important;
+                bottom: 10px !important;
+                left: 10px !important;
             }
         }
 


### PR DESCRIPTION
This PR addresses the latest feedback:

1.  **Mobile Equation Positioning**: The equations inside the charts (`L = ...` and `Raise s ...`) have been moved to the **bottom-left corner** on mobile devices, matching the user's preference.
2.  **Compact Desktop Controls**: The parameters/calibration section on the desktop version has been made more compact.
    *   Reduced padding inside the container.
    *   Reduced gap between grid items.
    *   Reduced minimum column width (`250px` -> `200px`).
    *   Slightly smaller font size for labels (`0.9rem`).
    *   Thinner slider tracks.

These changes improve the visual balance on desktop and ensure the mobile layout matches the user's specific request for equation placement.