### PR TITLE
Reduce chart height on mobile devices

### DIFF
--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -189,7 +189,7 @@
             }
             
             .chart-wrapper {
-                min-height: 300px;
+                min-height: 200px; /* Reduced from 300px to fit better on mobile screens */
                 padding: 0.5rem;
             }
 
@@ -550,7 +550,7 @@
                     plot_bgcolor: 'rgba(0,0,0,0)',
                     font: { color: textColor },
                     showlegend: false,
-                    margin: { t: 40, r: 20, l: 50, b: 40 },
+                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Tighter margins on mobile
                     shapes: [
                         {
                             type: 'line',
@@ -660,7 +660,7 @@
                     font: { color: textColor },
                     showlegend: true,
                     legend: { x: 0.95, y: 0.95, xanchor: 'right', yanchor: 'top', bgcolor: 'rgba(0,0,0,0)' },
-                    margin: { t: 40, r: 20, l: 50, b: 40 },
+                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Tighter margins on mobile
                     shapes: [
                         // Central Vertical leg (Height 1) - Red
                         {


### PR DESCRIPTION
This PR reduces the height of the charts on mobile devices to allow both charts and the parameters to fit better on a single vertical screen.

Changes:
- Reduced `min-height` of `.chart-wrapper` from `300px` to `200px` on mobile screens (`max-width: 768px`).
- Updated Plotly layout configuration to use tighter margins (`{ t: 30, r: 10, l: 40, b: 30 }`) when on mobile, ensuring the chart content remains legible despite the reduced height.

This change aims to improve the "at-a-glance" experience on mobile phones.