### PR TITLE
Update carousel timing and paper link colors

### DIFF
--- a/script_v2.js
+++ b/script_v2.js
@@ -180,7 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 
                 function startAutoPlay() {
-                    interval = setInterval(nextSlide, 4000);
+                    interval = setInterval(nextSlide, 5000);
                 }
                 
                 function stopAutoPlay() {

--- a/style_v2.css
+++ b/style_v2.css
@@ -47,6 +47,9 @@
     --tag-evolution: #68d391;
     --tag-implementation: #a0aec0;
     
+    /* Paper Link Color (Dark) */
+    --paper-link-color: #90cdf4; /* Light blue, softer than accent */
+    
     /* Tag Borders/Backgrounds (Dark) */
     --tag-bg-opacity: 0.05;
     --tag-border-opacity: 0.3;
@@ -81,6 +84,9 @@
 
     /* Journal Title (Light) */
     --journal-title-color: #1a202c;
+
+    /* Paper Link Color (Light) */
+    --paper-link-color: #63b3ed; /* Light blue, softer than accent */
 
     /* Tag Colors (Light) */
     --tag-structural: #805ad5;
@@ -342,13 +348,12 @@ p {
 
 /* Other links (See paper, etc) */
 .card blockquote > a:not(:first-child) {
-    color: var(--text-muted);
+    color: var(--paper-link-color);
     font-weight: 500;
-    font-size: 0.9rem;
 }
 
 .card blockquote > a:not(:first-child):hover {
-    color: var(--accent-color);
+    color: var(--link-hover-color);
 }
 
 /* Journal Names */


### PR DESCRIPTION
This PR implements the following changes based on user feedback:

1.  **Carousel Timing**: The auto-slide interval for the image carousels has been increased from 4 seconds to **5 seconds** to give users more time to view each image.
2.  **Paper Link Color**: The "See paper" links in the research section now use a **softer light blue** color (`#63b3ed` in light mode, `#90cdf4` in dark mode) to distinguish them from the main paper titles while maintaining good visibility.

These changes affect `script_v2.js` and `style_v2.css`.