### PR TITLE
Revert link colors and further reduce mobile chart height

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
                         <a href="#popup34">Physicians’ Occupational Licensing and the Quantity-Quality Trade-Off</a>, with J. P. Atal, P. Muñoz, and C. Otero.
                         <br>
                         <a href="https://cristobalotero.github.io/files/physicians.pdf">[See paper]</a>
-                        <a href="licensing_simulation.html" style="color: var(--accent-color); font-weight: bold; margin-left: 10px;">[Try Simulation]</a>
+                        <a href="licensing_simulation.html" style="color: var(--text-muted); font-weight: 500; margin-left: 10px;">[Try Simulation]</a>
                         <div class="tags-container">
                             <span class="tag tag-health">Health</span>
                             <span class="tag tag-labor">Labor</span>

--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -189,7 +189,7 @@
             }
             
             .chart-wrapper {
-                min-height: 200px; /* Reduced from 300px to fit better on mobile screens */
+                min-height: 160px; /* Reduced from 200px to fit better on mobile screens */
                 padding: 0.5rem;
             }
 

--- a/style_v2.css
+++ b/style_v2.css
@@ -348,12 +348,12 @@ p {
 
 /* Other links (See paper, etc) */
 .card blockquote > a:not(:first-child) {
-    color: var(--paper-link-color);
+    color: var(--text-muted);
     font-weight: 500;
 }
 
 .card blockquote > a:not(:first-child):hover {
-    color: var(--link-hover-color);
+    color: var(--accent-color);
 }
 
 /* Journal Names */


### PR DESCRIPTION
This PR addresses the latest feedback:

1.  **Revert Link Colors**: The "See paper" links have been reverted to their original grey color (`var(--text-muted)`).
2.  **Try Simulation Link**: The "Try Simulation" link has also been updated to match this grey color (`var(--text-muted)`), ensuring consistency.
3.  **Mobile Chart Height**: The minimum height of the charts on mobile devices has been further reduced from `200px` to `160px`. This should allow both charts to fit vertically on a standard mobile screen without excessive scrolling.

These changes affect `index.html`, `style_v2.css`, and `licensing_simulation.html`.