### PR TITLE
Fix mobile chart aspect ratio and restore padding

### DIFF
--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -534,24 +534,29 @@
                 };
 
                 const layoutDist = {
-                    title: 'Distribution of Test Takers',
+                    title: {
+                        text: 'Distribution of Test Takers',
+                        font: { size: window.innerWidth < 768 ? 14 : 17 }
+                    },
                     xaxis: { 
                         title: 'Score (s)', 
                         range: [0, 100],
                         gridcolor: gridColor,
-                        zerolinecolor: zeroLineColor
+                        zerolinecolor: zeroLineColor,
+                        automargin: true
                     },
                     yaxis: { 
                         title: 'Density',
                         gridcolor: gridColor,
-                        zerolinecolor: zeroLineColor
+                        zerolinecolor: zeroLineColor,
+                        automargin: true
                     },
                     paper_bgcolor: 'rgba(0,0,0,0)',
                     plot_bgcolor: 'rgba(0,0,0,0)',
-                    font: { color: textColor },
+                    font: { color: textColor, size: window.innerWidth < 768 ? 10 : 12 },
                     showlegend: false,
-                    height: window.innerWidth < 768 ? 200 : undefined, // Explicit height for mobile aspect ratio
-                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
+                    height: window.innerWidth < 768 ? 220 : undefined, // Explicit height for mobile aspect ratio
+                    margin: window.innerWidth < 768 ? { t: 40, r: 10, l: 40, b: 40 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
                     shapes: [
                         {
                             type: 'line',
@@ -645,24 +650,29 @@
                 };
 
                 const layoutTradeoff = {
-                    title: 'Quantity-Quality Trade-off',
+                    title: {
+                        text: 'Quantity-Quality Trade-off',
+                        font: { size: window.innerWidth < 768 ? 14 : 17 }
+                    },
                     xaxis: { 
                         title: 'Average Quality',
                         gridcolor: gridColor,
-                        zerolinecolor: zeroLineColor
+                        zerolinecolor: zeroLineColor,
+                        automargin: true
                     },
                     yaxis: { 
                         title: 'ln(Labor Supply)',
                         gridcolor: gridColor,
-                        zerolinecolor: zeroLineColor
+                        zerolinecolor: zeroLineColor,
+                        automargin: true
                     },
                     paper_bgcolor: 'rgba(0,0,0,0)',
                     plot_bgcolor: 'rgba(0,0,0,0)',
-                    font: { color: textColor },
+                    font: { color: textColor, size: window.innerWidth < 768 ? 10 : 12 },
                     showlegend: true,
                     legend: { x: 0.95, y: 0.95, xanchor: 'right', yanchor: 'top', bgcolor: 'rgba(0,0,0,0)' },
-                    height: window.innerWidth < 768 ? 200 : undefined, // Explicit height for mobile aspect ratio
-                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
+                    height: window.innerWidth < 768 ? 220 : undefined, // Explicit height for mobile aspect ratio
+                    margin: window.innerWidth < 768 ? { t: 40, r: 10, l: 40, b: 40 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
                     shapes: [
                         // Central Vertical leg (Height 1) - Red
                         {

--- a/licensing_simulation.html
+++ b/licensing_simulation.html
@@ -189,8 +189,8 @@
             }
             
             .chart-wrapper {
-                min-height: 120px; /* Drastically reduced to fit both on screen */
-                padding: 0.25rem; /* Minimal padding */
+                min-height: auto; /* Let Plotly control height */
+                padding: 0.5rem; /* Restore padding */
             }
 
             /* Single column controls for better touch targets */
@@ -550,7 +550,8 @@
                     plot_bgcolor: 'rgba(0,0,0,0)',
                     font: { color: textColor },
                     showlegend: false,
-                    margin: window.innerWidth < 768 ? { t: 20, r: 5, l: 30, b: 20 } : { t: 40, r: 20, l: 50, b: 40 }, // Very tight margins on mobile
+                    height: window.innerWidth < 768 ? 200 : undefined, // Explicit height for mobile aspect ratio
+                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
                     shapes: [
                         {
                             type: 'line',
@@ -660,7 +661,8 @@
                     font: { color: textColor },
                     showlegend: true,
                     legend: { x: 0.95, y: 0.95, xanchor: 'right', yanchor: 'top', bgcolor: 'rgba(0,0,0,0)' },
-                    margin: window.innerWidth < 768 ? { t: 20, r: 5, l: 30, b: 20 } : { t: 40, r: 20, l: 50, b: 40 }, // Very tight margins on mobile
+                    height: window.innerWidth < 768 ? 200 : undefined, // Explicit height for mobile aspect ratio
+                    margin: window.innerWidth < 768 ? { t: 30, r: 10, l: 40, b: 30 } : { t: 40, r: 20, l: 50, b: 40 }, // Compact but readable margins
                     shapes: [
                         // Central Vertical leg (Height 1) - Red
                         {


### PR DESCRIPTION
This PR fixes the mobile chart display issues by:
1. Restoring the padding in `.chart-wrapper` to `0.5rem` (reverting the removal).
2. Explicitly setting the Plotly chart height to `200px` on mobile devices to enforce a better aspect ratio (squatter charts) while maintaining readability.
3. Adjusting chart margins on mobile to ensure labels are not cut off with the new height.